### PR TITLE
Configure TTS fillers

### DIFF
--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -97,6 +97,7 @@ const speechstate = createMachine(
                           audioContext: context.audioContext,
                           azureCredentials: context.settings.azureCredentials,
                           azureRegion: context.settings.azureRegion,
+                          ttsFillers: context.settings.ttsFillers,
                         },
                       });
                     },

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -15,6 +15,7 @@ interface TTSInit {
   azureRegion: string;
   ttsDefaultVoice: string;
   ttsLexicon?: string;
+  ttsFillers?: string[];
 }
 
 interface TTSContext extends TTSInit {
@@ -53,6 +54,10 @@ type TTSEvent =
 
 const UTTERANCE_CHUNK_REGEX = /(^.*([!?]+|([.,]+\s)))/;
 
+function randomChoice(xs: Array<any>) {
+  return xs[Math.floor(xs.length * Math.random())];
+}
+
 export const ttsMachine = setup({
   types: {} as {
     input: TTSInit;
@@ -68,7 +73,9 @@ export const ttsMachine = setup({
       return {
         buffer:
           context.buffer.substring(0, spaceIndex) +
-          " um," +
+          (context.ttsFillers
+            ? " " + randomChoice(context.ttsFillers)
+            : " um,") +
           context.buffer.substring(spaceIndex),
       };
     }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Settings {
   speechRecognitionEndpointId?: string;
   ttsDefaultVoice?: string;
   ttsLexicon?: string;
+  ttsFillers?: string[];
 }
 
 export interface Agenda {


### PR DESCRIPTION
Add a parameter to `speechstate` and `tts` contexts which allows
configuring fillers (list of strings) for TTS streaming. When filler
is needed, it gets randomly chosen from the provided list.