### PR TITLE
Support setting voice inside the TTS stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speechstate",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "GPL-3.0",
   "homepage": "http://localhost/speechstate",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export {
   Agenda,
   RecogniseParameters,
 } from "./types";
+
+export type { SpeechStateExternalEvent } from "./types";

--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -8,7 +8,7 @@ import {
 import { ttsMachine } from "./tts";
 import { asrMachine } from "./asr";
 
-import { Settings, Agenda, Hypothesis, RecogniseParameters } from "./types";
+import { Settings, SpeechStateEvent } from "./types";
 interface SSContext {
   settings: Settings;
   audioContext?: AudioContext;
@@ -16,36 +16,12 @@ interface SSContext {
   ttsRef?: any;
 }
 
-/** events sent to the spawned `speechstate` machine **/
-type SSEventExtIn =
-  | { type: "PREPARE" }
-  | { type: "CONTROL" }
-  | { type: "STOP" }
-  | { type: "SPEAK"; value: Agenda }
-  | { type: "LISTEN"; value: RecogniseParameters };
-
-/** for sendParent, not type-checked */
-type SSEventExtOut =
-  | { type: "ASR_NOINPUT" }
-  | { type: "ASRTTS_READY" }
-  | { type: "ASR_STARTED" }
-  | { type: "TTS_STARTED" }
-  | { type: "SPEAK_COMPLETE" }
-  | { type: "RECOGNISED"; value: Hypothesis[]; nluValue?: any };
-
-type SSEventIntIn =
-  | { type: "TTS_READY" }
-  | { type: "ASR_READY" }
-  | { type: "TTS_ERROR" };
-
-type SSEvent = SSEventIntIn | SSEventExtIn | SSEventExtOut;
-
 const speechstate = createMachine(
   {
     types: {} as {
       input: Settings;
       context: SSContext;
-      events: SSEvent;
+      events: SpeechStateEvent;
     },
     context: ({ input }) => ({
       settings: input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,3 +46,28 @@ export interface RecogniseParameters {
   hints?: string[];
   nlu?: boolean | AzureLanguageCredentials;
 }
+
+/** events sent to the spawned `speechstate` machine **/
+type SSEventExtIn =
+  | { type: "PREPARE" }
+  | { type: "CONTROL" }
+  | { type: "STOP" }
+  | { type: "SPEAK"; value: Agenda }
+  | { type: "LISTEN"; value: RecogniseParameters };
+
+/** for sendParent, not type-checked */
+type SSEventExtOut =
+  | { type: "ASR_NOINPUT" }
+  | { type: "ASRTTS_READY" }
+  | { type: "ASR_STARTED" }
+  | { type: "TTS_STARTED" }
+  | { type: "SPEAK_COMPLETE" }
+  | { type: "RECOGNISED"; value: Hypothesis[]; nluValue?: any };
+
+type SSEventIntIn =
+  | { type: "TTS_READY" }
+  | { type: "ASR_READY" }
+  | { type: "TTS_ERROR" };
+
+export type SpeechStateExternalEvent = SSEventExtIn | SSEventExtOut;
+export type SpeechStateEvent = SSEventIntIn | SpeechStateExternalEvent;


### PR DESCRIPTION
This change supports switching voice on the fly according to
STREAMING_SET_VOICE event. This sets a local variable to the event
value. If there is no such value, TTS voice falls back to default
voice.