### PR TITLE
Locale support for TTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speechstate",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "GPL-3.0",
   "homepage": "http://localhost/speechstate",
   "main": "./dist/index.js",

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -7,13 +7,14 @@ import {
   Settings,
 } from "./types";
 import { createBrowserInspector } from "@statelyai/inspect";
+import { AZURE_KEY } from "./credentials";
 
 const inspector = createBrowserInspector();
 
 const azureSpeechCredentials: AzureSpeechCredentials = {
   endpoint:
-    "https://northeurope.api.cognitive.microsoft.com/sts/v1.0/issuetoken",
-  key: "",
+    "https://swedencentral.api.cognitive.microsoft.com/sts/v1.0/issuetoken",
+  key: AZURE_KEY,
 };
 
 const azureLanguageCredentials: AzureLanguageCredentials = {
@@ -26,11 +27,11 @@ const azureLanguageCredentials: AzureLanguageCredentials = {
 
 const settings: Settings = {
   azureCredentials: azureSpeechCredentials,
-  azureRegion: "northeurope",
+  azureRegion: "swedencentral",
   azureLanguageCredentials: azureLanguageCredentials,
   asrDefaultCompleteTimeout: 0,
   asrDefaultNoInputTimeout: 5000,
-  locale: "en-US",
+  locale: "sv-SE",
   ttsDefaultVoice: "en-US-DavisNeural",
   // speechRecognitionEndpointId: "",
 };

--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -40,6 +40,7 @@ const speechstate = setup({
             audioContext: context.audioContext,
             azureCredentials: context.settings.azureCredentials,
             azureRegion: context.settings.azureRegion,
+            locale: context.settings.locale,
           },
         });
       },

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -123,6 +123,7 @@ export const ttsMachine = setup({
         const content = wrapSSML(
           (input as any).utterance,
           (input as any).voice,
+          (input as any).locale,
           (input as any).ttsLexicon,
           1,
         ); // todo speech rate;
@@ -163,6 +164,7 @@ export const ttsMachine = setup({
     audioContext: input.audioContext,
     azureCredentials: input.azureCredentials,
     azureRegion: input.azureRegion,
+    locale: input.locale || "en-US",
     buffer: "",
   }),
   initial: "GetToken",
@@ -397,6 +399,7 @@ export const ttsMachine = setup({
                             context.currentVoice ||
                             context.agenda.voice ||
                             context.ttsDefaultVoice,
+                          locale: context.locale,
                           utterance: context.utteranceFromStream,
                         }),
                       },
@@ -441,6 +444,7 @@ export const ttsMachine = setup({
                   ttsLexicon: context.ttsLexicon,
                   voice: context.agenda.voice || context.ttsDefaultVoice,
                   // streamURL: context.agenda.streamURL,
+                  locale: context.locale,
                   utterance: context.agenda.utterance,
                 }),
               },
@@ -500,16 +504,18 @@ export const ttsMachine = setup({
 const wrapSSML = (
   text: string,
   voice: string,
+  locale: string,
   lexicon: string,
   speechRate: number,
 ): string => {
-  let content = `<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xmlns:mstts="http://www.w3.org/2001/mstts" xml:lang="en-US"><voice name="${voice}">`;
+  let content = `<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xmlns:mstts="http://www.w3.org/2001/mstts" xml:lang="en-US"><voice name="${voice}"><lang xml:lang="${locale}">`;
   if (lexicon) {
     content = content + `<lexicon uri="${lexicon}"/>`;
   }
   content =
     content +
     `<prosody rate="${speechRate}">` +
-    `${text}</prosody></voice></speak>`;
+    `${text}</prosody></lang></voice></speak>`;
+  console.debug(content);
   return content;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface TTSInit {
   azureRegion: string;
   ttsDefaultVoice: string;
   ttsLexicon?: string;
+  locale: string;
 }
 
 export interface TTSContext extends TTSInit {


### PR DESCRIPTION
This change introduces a `<lang>` SSML tag in every TTS output. For now,
the language depends on the global locale setting. This change doesn't
affect Open AI neural voices which are multilingual, but don't support
`<lang>` SSML tag (`<lang>` tag will be ignored).