### PR TITLE
WIP Enable a barge-in option for TTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "microsoft-cognitiveservices-speech-sdk": "^1.43.1",
     "reconnecting-eventsource": "^1.6.4",
     "web-speech-cognitive-services": "^8.1.1",
-    "xstate": "^5.17.4"
+    "xstate": "^5.19.2"
   },
   "scripts": {
     "dev": "vite",

--- a/src/asr.ts
+++ b/src/asr.ts
@@ -7,6 +7,7 @@ import {
   raise,
   cancel,
   sendTo,
+  EventObject,
 } from "xstate";
 
 import {
@@ -367,14 +368,14 @@ export const asrMachine = setup({
             input: ({ context }) => {
               let c: AzureLanguageCredentials;
               typeof context.params.nlu === "boolean"
-                ? (c = context.azureLanguageCredentials)
-                : (c = context.params.nlu);
+                ? (c = context.azureLanguageCredentials!)
+                : (c = context.params.nlu as AzureLanguageCredentials);
               return {
                 endpoint: c.endpoint,
                 key: c.key,
                 projectName: c.projectName,
                 deploymentName: c.deploymentName,
-                query: context.result[0].utterance,
+                query: context.result![0].utterance,
                 locale: (context.params || {}).locale || context.locale,
               };
             },

--- a/src/asr.ts
+++ b/src/asr.ts
@@ -28,7 +28,7 @@ export const asrMachine = setup({
   },
   delays: {
     noinputTimeout: ({ context }) =>
-      (context.params || {}).noInputTimeout || context.asrDefaultNoInputTimeout,
+      context.params.noInputTimeout ?? context.asrDefaultNoInputTimeout,
   },
   actions: {
     raise_noinput_after_timeout: raise(
@@ -42,7 +42,7 @@ export const asrMachine = setup({
   },
   guards: {
     nlu_is_activated: ({ context }) => {
-      const nlu = (context.params || {}).nlu;
+      const nlu = context.params.nlu;
       if (nlu) {
         if (typeof nlu === "object") {
           return true;
@@ -182,6 +182,7 @@ export const asrMachine = setup({
     azureRegion: input.azureRegion,
     azureLanguageCredentials: input.azureLanguageCredentials,
     speechRecognitionEndpointId: input.speechRecognitionEndpointId,
+    params: {},
   }),
   initial: "Ready",
   on: {
@@ -213,12 +214,11 @@ export const asrMachine = setup({
           azureRegion: context.azureRegion,
           audioContext: context.audioContext,
           azureAuthorizationToken: context.azureAuthorizationToken,
-          locale: (context.params || {}).locale || context.locale,
+          locale: context.params.locale || context.locale,
           speechRecognitionEndpointId: context.speechRecognitionEndpointId,
           completeTimeout:
-            (context.params || {}).completeTimeout ||
-            context.asrDefaultCompleteTimeout,
-          hints: (context.params || {}).hints,
+            context.params.completeTimeout || context.asrDefaultCompleteTimeout,
+          hints: context.params.hints,
         }),
       },
       on: {
@@ -285,7 +285,12 @@ export const asrMachine = setup({
             },
             ApplyNoInputTimeout: {
               entry: [
-                () => console.debug("[ASR] START_NOINPUT_TIMEOUT"),
+                ({ context }) =>
+                  console.debug(
+                    "[ASR] START_NOINPUT_TIMEOUT",
+                    context.params.noInputTimeout ??
+                      context.asrDefaultNoInputTimeout,
+                  ),
                 { type: "raise_noinput_after_timeout" },
               ],
             },

--- a/src/asr.ts
+++ b/src/asr.ts
@@ -269,11 +269,25 @@ export const asrMachine = setup({
           },
         },
         NoInput: {
-          entry: { type: "raise_noinput_after_timeout" },
+          initial: "Wait",
           on: {
             STARTSPEECH: {
               target: "InProgress",
-              actions: cancel("completeTimeout"),
+              actions: [
+                sendParent({ type: "STARTSPEECH" }),
+                cancel("completeTimeout"),
+              ],
+            },
+          },
+          states: {
+            Wait: {
+              on: { START_NOINPUT_TIMEOUT: "ApplyNoInputTimeout" },
+            },
+            ApplyNoInputTimeout: {
+              entry: [
+                () => console.debug("[ASR] START_NOINPUT_TIMEOUT"),
+                { type: "raise_noinput_after_timeout" },
+              ],
             },
           },
           exit: { type: "cancel_noinput_timeout" },

--- a/src/asr.ts
+++ b/src/asr.ts
@@ -203,6 +203,15 @@ export const asrMachine = setup({
             params: event.value,
           })),
         },
+        UPDATE_ASR_PARAMS: {
+          actions: [
+            ({ event }) =>
+              console.debug("[ASR] UPDATE_ASR_PARAMS", event.value),
+            assign(({ event }) => ({
+              params: event.value,
+            })),
+          ],
+        },
       },
     },
     Recognising: {

--- a/src/asr.ts
+++ b/src/asr.ts
@@ -199,8 +199,8 @@ export const asrMachine = setup({
       on: {
         START: {
           target: "Recognising",
-          actions: assign(({ event }) => ({
-            params: event.value,
+          actions: assign(({ context, event }) => ({
+            params: { ...context.params, ...event.value },
           })),
         },
         UPDATE_ASR_PARAMS: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { speechstate } from "./speechstate";
 export {
-  AzureCredentials,
+  AzureSpeechCredentials,
   Settings,
   Hypothesis,
   Agenda,

--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -92,6 +92,11 @@ const speechstate = setup({
         });
       },
     }),
+    "tts.stop": ({ context, event }) =>
+      context.ttsRef.send({
+        type: "STOP",
+        value: (event as any).value,
+      }),
   },
   delays: {
     NEW_TOKEN_INTERVAL: ({ context }) => {
@@ -341,6 +346,16 @@ const speechstate = setup({
                         })),
                       ],
                     },
+                    UPDATE_ASR_PARAMS: {
+                      actions: [
+                        () => console.debug("[SpSt→ASR] UPDATE_ASR_PARAMS"),
+                        ({ context, event }) =>
+                          context.asrRef.send({
+                            type: "UPDATE_ASR_PARAMS",
+                            value: event.value,
+                          }),
+                      ],
+                    },
                     SPEAK_COMPLETE: [
                       {
                         target: "Recognising",
@@ -429,11 +444,7 @@ const speechstate = setup({
                               console.debug(
                                 "[ASR→SpSt] STARTSPEECH (barge-in)",
                               ),
-                            ({ context, event }) =>
-                              context.ttsRef.send({
-                                type: "STOP",
-                                value: (event as any).value,
-                              }),
+                            { type: "tts.stop" },
                           ],
                         },
                         CONTROL: {

--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -40,8 +40,8 @@ const speechstate = setup({
       navigator.mediaDevices
         .getUserMedia({
           audio: {
-            echoCancellation: false, // Enable echo cancellation
-            noiseSuppression: false, // Optional: Enable noise suppression
+            // echoCancellation: false, // Enable echo cancellation
+            // noiseSuppression: false, // Optional: Enable noise suppression
             autoGainControl: false, // Optional: Enable automatic gain control
           },
         })

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -387,13 +387,13 @@ export const ttsMachine = setup({
                   initial: "BufferIdle",
                   on: {
                     STREAMING_SET_VOICE: {
-                      actions: "assignCurrentVoice",
+                      actions: { type: "assignCurrentVoice" },
                     },
                     STREAMING_SET_LOCALE: {
                       actions: "assignCurrentLocale",
                     },
                     STREAMING_SET_PERSONA: {
-                      actions: "sendParentCurrentPersona",
+                      actions: { type: "sendParentCurrentPersona" },
                     },
                   },
                   states: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,11 +69,13 @@ type SSEventExtOut =
   | { type: "LISTEN_COMPLETE" }
   | { type: "RECOGNISED"; value: Hypothesis[]; nluValue?: any }
   | { type: "VISEME"; value: any }
+  | { type: "FURHAT_BLENDSHAPES"; value: Frame[] }
   | { type: "STREAMING_SET_PERSONA"; value: string };
 
 type SSEventIntIn =
   | { type: "TTS_READY" }
   | { type: "ASR_READY" }
+  | { type: "STARTSPEECH" }
   | { type: "TTS_ERROR" };
 
 export type SpeechStateExternalEvent = SSEventExtIn | SSEventExtOut;

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export type ASREvent =
 export interface ASRContext extends ASRInit {
   result?: Hypothesis[];
   nluResult?: any; // TODO
-  params?: RecogniseParameters;
+  params: RecogniseParameters;
 }
 
 export interface ASRInit {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,6 @@ export interface AzureSpeechCredentials {
   key: string;
 }
 
-/**
- * @deprecated use `AzureSpeechCredentials` instead
- */
-export interface AzureCredentials extends AzureSpeechCredentials {}
-
 export interface AzureLanguageCredentials {
   endpoint: string;
   key: string;
@@ -157,7 +152,7 @@ export interface TTSContext extends TTSInit {
     new (text?: string): SpeechSynthesisUtterance;
   };
   agenda?: Agenda;
-  buffer?: string;
+  buffer: string;
   currentVoice?: string;
   currentLocale?: string;
   utteranceFromStream?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface Settings {
 export interface Agenda {
   utterance: string;
   locale?: string;
+  bargeIn: false | RecogniseParameters;
   voice?: string;
   stream?: string;
   cache?: string;
@@ -60,7 +61,7 @@ type SSEventExtIn =
   | { type: "PREPARE" }
   | { type: "CONTROL" }
   | { type: "STOP" }
-  | { type: "SPEAK"; value: Agenda }
+  | TTSSpeakEvent
   | { type: "LISTEN"; value: RecogniseParameters };
 
 type SSEventExtOut =
@@ -106,6 +107,7 @@ export type ASREvent =
   | { type: "LISTEN_COMPLETE" }
   | { type: "RESULT"; value: Hypothesis[] }
   | { type: "FINAL_RESULT" };
+  | { type: "START_NOINPUT_TIMEOUT" };
 
 export interface ASRContext extends ASRInit {
   result?: Hypothesis[];
@@ -186,7 +188,7 @@ export type TTSEvent =
       };
     }
   | { type: "ERROR" }
-  | { type: "SPEAK"; value: Agenda }
+  | TTSSpeakEvent
   | { type: "TTS_STARTED"; value?: AudioBufferSourceNode }
   | { type: "STREAMING_CHUNK"; value: string }
   | { type: "STREAMING_SET_VOICE"; value: string }
@@ -196,6 +198,8 @@ export type TTSEvent =
   | { type: "SPEAK_COMPLETE" }
   // | { type: "VISEME"; value: SpeechSynthesisEventProps }
   | { type: "FURHAT_BLENDSHAPES"; value: Frame[] };
+
+export type TTSSpeakEvent = { type: "SPEAK"; value: Agenda };
 
 export type Frame = { time: number[]; params: any };
 export type Animation = { FrameIndex: number; BlendShapes: number[][] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,8 @@ type SSEventExtIn =
   | { type: "CONTROL" }
   | { type: "STOP" }
   | TTSSpeakEvent
-  | { type: "LISTEN"; value: RecogniseParameters };
+  | { type: "LISTEN"; value: RecogniseParameters }
+  | { type: "UPDATE_ASR_PARAMS"; value: RecogniseParameters };
 
 type SSEventExtOut =
   | { type: "ASR_NOINPUT" }
@@ -84,10 +85,7 @@ export type SpeechStateExternalEvent = SSEventExtIn | SSEventExtOut;
 export type SpeechStateEvent = SSEventIntIn | SpeechStateExternalEvent;
 
 export interface MySpeechRecognition extends SpeechRecognition {
-  new ();
-}
-export interface MySpeechGrammarList extends SpeechGrammarList {
-  new ();
+  new (): MySpeechRecognition;
 }
 
 export type ASREvent =
@@ -100,6 +98,7 @@ export type ASREvent =
       type: "START";
       value?: RecogniseParameters;
     }
+  | { type: "UPDATE_ASR_PARAMS"; value: RecogniseParameters }
   | { type: "STARTED"; value: { wsaASRinstance: MySpeechRecognition } }
   | { type: "STARTSPEECH" }
   | { type: "RECOGNISED"; value: Hypothesis[] }

--- a/src/visemes.ts
+++ b/src/visemes.ts
@@ -1,4 +1,4 @@
-import { setup, assign, fromPromise, sendParent, stopChild } from "xstate";
+import { setup, sendParent } from "xstate";
 import { Frame, Animation } from "./types";
 
 const blendShapeToFrameParams = (blendShapes: number[]) => {
@@ -68,7 +68,7 @@ const animationToFrames = (animation: Animation): Frame[] => {
   return [...frames];
 };
 
-const blendShapeMap = {
+const blendShapeMap: { [index: number]: string } = {
   1: "EYE_BLINK_LEFT",
   2: "EYE_LOOK_DOWN_LEFT",
   3: "EYE_LOOK_IN_LEFT",

--- a/test/tts.test.ts
+++ b/test/tts.test.ts
@@ -36,6 +36,12 @@ describe("Synthesis test", async () => {
       console.debug("[test.TTS state]", snapshot.value),
     );
 
+  actor
+    .getSnapshot()
+    .context.ssRef.subscribe((snapshot: any) =>
+      console.log("[test.SpSt state]", snapshot.value),
+    );
+
   beforeEach(async () => {
     await waitForView(actor, "idle", 20_000);
   });
@@ -115,7 +121,7 @@ describe("Synthesis test", async () => {
       type: "SPEAK",
       value: { utterance: "", stream: "http://localhost:3000/sse/1" },
     });
-    await waitForView(actor, "speaking", 500);
+    await waitForView(actor, "speaking", 1000);
     await pause(1000);
     actor.getSnapshot().context.ssRef.send({ type: "CONTROL" });
     await waitForView(actor, "speaking-paused", 3000);
@@ -269,6 +275,19 @@ describe("Synthesis test", async () => {
       value: { utterance: "And hello!" },
     });
     const snapshot = await waitForView(actor, "speaking", 500);
+    expect(snapshot).toBeTruthy();
+  });
+
+  test.only("synthesise with barge-in", async () => {
+    actor.getSnapshot().context.ssRef.send({
+      type: "SPEAK",
+      value: {
+        utterance: "Hello! You can interrupt me whenever you like.",
+        voice: "en-US-EmmaMultilingualNeural",
+        bargeIn: { noInputTimeout: 10_000 },
+      },
+    });
+    const snapshot = await waitForView(actor, "listening", 5000);
     expect(snapshot).toBeTruthy();
   });
 });

--- a/test/tts.test.ts
+++ b/test/tts.test.ts
@@ -284,7 +284,7 @@ describe("Synthesis test", async () => {
       value: {
         utterance: "Hello! You can interrupt me whenever you like.",
         voice: "en-US-EmmaMultilingualNeural",
-        bargeIn: { noInputTimeout: 10_000 },
+        bargeIn: { noInputTimeout: 0 },
       },
     });
     const snapshot = await waitForView(actor, "listening", 5000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2016",
-    // "strict": true,
+    "strict": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6973,7 +6973,7 @@ __metadata:
     web-speech-cognitive-services: ^8.1.1
     webdriverio: ^9.2.8
     ws: ^8.16.0
-    xstate: ^5.17.4
+    xstate: ^5.19.2
   languageName: unknown
   linkType: soft
 
@@ -8098,10 +8098,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xstate@npm:^5.17.4":
-  version: 5.18.1
-  resolution: "xstate@npm:5.18.1"
-  checksum: 5933575ae536ec13eb781f7fa3fb9ef360f56612ddbb903d26135a01e04fb764c67afe62394c1635e9bb0262fe111f7fecaccff69b781d705a163629dd464fb3
+"xstate@npm:^5.19.2":
+  version: 5.19.2
+  resolution: "xstate@npm:5.19.2"
+  checksum: 161d457e3b648bad17c7c434b8f1b06cb3f3880c76dca987b6c69b7dc6c1cec84315017ae6fdab95b0c08f0129e4c0e7b939ce6749cd06e5df55d7221920038b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This change adds a barge-in option in `SPEAK` event. It can be either
false (default) or an object containing `RecogniseParameters`. The
object can be also empty for default parameters.

Additional event was added in `asr.ts` to handle noInput timeout in a
correct way.

TODO:
- [ ] check if RecogniseParameters are passed correctly
- [ ] test coverage
- [ ] check parameters of audioContext (echo cancellation etc)
- [ ] make barge-in compatible with NLU