### PR TITLE
Stop streaming after timeout for next chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speechstate",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "license": "GPL-3.0",
   "homepage": "http://localhost/speechstate",
   "main": "./dist/index.js",

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -31,6 +31,9 @@ async function run() {
         words =
           "Hello, |this |is |a |<v>|test |of stre|aming |messa|ges |one |by |one!| |[end]";
         break;
+      case "noend":
+        words = "Hello, |this |is |a";
+        break;
     }
     words = words.split("|");
     const interval = setInterval(() => {

--- a/test/tts.test.ts
+++ b/test/tts.test.ts
@@ -171,4 +171,14 @@ describe("Synthesis test", async () => {
     const snapshot = await waitForView(actor, "speaking", 1000);
     expect(snapshot).toBeTruthy();
   });
+
+  test.only("synthesise from stream, go to idle state after timeout", async () => {
+    actor.getSnapshot().context.ssRef.send({
+      type: "SPEAK",
+      value: { utterance: "", stream: "http://localhost:3000/sse/noend" },
+    });
+    await waitForView(actor, "speaking", 1000);
+    const snapshot = await waitForView(actor, "idle", 15_000);
+    expect(snapshot).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This change introduces STREAMING_TIMEOUT (set to 10 seconds). When the
timeout is reached, TTS moves to a idle state and throws a
SPEAK_COMPLETE event, like it normally does after
speaking. Additionally, an error is logged in browser console.

This change also enables logging the utterances which are played from
a cache.