### PR TITLE
Support locale setting for SPEAK event and streaming

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,14 +66,19 @@ Example action:
 ** Types:
 #+begin_src typescript
   interface Hypothesis {
-      utterance: string;
-      confidence: number;
+    utterance: string;
+    confidence: number;
   }
 
   interface Agenda {
     utterance: string;
     voice?: string; // defaults to "en-US-DavisNeural"
-    streamURL?: string;
+    locale?: string;
+    stream?: string;
+    cache?: string;
+    fillerDelay?: number;
+    visemes?: boolean;
+    audioURL?: string;
   }
 
   interface RecogniseParameters {
@@ -90,7 +95,6 @@ Example action:
     projectName: string;
     deploymentName: string;
   }
-
 #+end_src
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speechstate",
-  "version": "2.10.0",
   "license": "GPL-3.0",
+  "version": "2.11.0",
   "homepage": "http://localhost/speechstate",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -55,6 +55,17 @@ export const ttsMachine = setup({
         };
       },
     ),
+    assignCurrentLocale: assign(
+      ({
+        event,
+      }: {
+        event: { type: "STREAMING_SET_LOCALE"; value: string };
+      }) => {
+        return {
+          currentLocale: event.value,
+        };
+      },
+    ),
     sendParentCurrentPersona: sendParent(
       ({
         event,
@@ -151,6 +162,9 @@ export const ttsMachine = setup({
         });
         eventSource.addEventListener("STREAMING_SET_VOICE", (event) => {
           sendBack({ type: "STREAMING_SET_VOICE", value: event.data });
+        });
+        eventSource.addEventListener("STREAMING_SET_LOCALE", (event) => {
+          sendBack({ type: "STREAMING_SET_LOCALE", value: event.data });
         });
         eventSource.addEventListener("STREAMING_SET_PERSONA", (event) => {
           sendBack({ type: "STREAMING_SET_PERSONA", value: event.data });
@@ -328,6 +342,9 @@ export const ttsMachine = setup({
                     STREAMING_SET_VOICE: {
                       actions: "assignCurrentVoice",
                     },
+                    STREAMING_SET_LOCALE: {
+                      actions: "assignCurrentLocale",
+                    },
                     STREAMING_SET_PERSONA: {
                       actions: "sendParentCurrentPersona",
                     },
@@ -451,7 +468,10 @@ export const ttsMachine = setup({
                                 context.currentVoice ||
                                 context.agenda.voice ||
                                 context.ttsDefaultVoice,
-                              locale: context.locale,
+                              locale:
+                                context.currentLocale ||
+                                context.agenda.locale ||
+                                context.locale,
                             }),
                             onError: "Go",
                             onDone: [
@@ -489,7 +509,10 @@ export const ttsMachine = setup({
                                     context.currentVoice ||
                                     context.agenda.voice ||
                                     context.ttsDefaultVoice,
-                                  locale: context.locale,
+                                  locale:
+                                    context.currentLocale ||
+                                    context.agenda.locale ||
+                                    context.locale,
                                 }),
                                 onDone: {
                                   target: "PlayAudio",
@@ -560,7 +583,10 @@ export const ttsMachine = setup({
                                 context.currentVoice ||
                                 context.agenda.voice ||
                                 context.ttsDefaultVoice,
-                              locale: context.locale,
+                              locale:
+                                context.currentLocale ||
+                                context.agenda.locale ||
+                                context.locale,
                               utterance: context.utteranceFromStream,
                             }),
                           },
@@ -701,7 +727,10 @@ export const ttsMachine = setup({
                       voice: context.agenda.voice || context.ttsDefaultVoice,
                       visemes: context.agenda.visemes,
                       // streamURL: context.agenda.streamURL,
-                      locale: context.locale,
+                      locale:
+                        context.currentLocale ||
+                        context.agenda.locale ||
+                        context.locale,
                       utterance: context.agenda.utterance,
                     }),
                   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface Settings {
 
 export interface Agenda {
   utterance: string;
+  locale?: string;
   voice?: string;
   stream?: string;
   cache?: string;
@@ -155,6 +156,7 @@ export interface TTSContext extends TTSInit {
   agenda?: Agenda;
   buffer?: string;
   currentVoice?: string;
+  currentLocale?: string;
   utteranceFromStream?: string;
   audioBuffer?: AudioBuffer;
   audioBufferSourceNode?: AudioBufferSourceNode;
@@ -183,6 +185,7 @@ export type TTSEvent =
   | { type: "TTS_STARTED"; value?: AudioBufferSourceNode }
   | { type: "STREAMING_CHUNK"; value: string }
   | { type: "STREAMING_SET_VOICE"; value: string }
+  | { type: "STREAMING_SET_LOCALE"; value: string }
   | { type: "STREAMING_SET_PERSONA"; value: string }
   | { type: "STREAMING_DONE" }
   | { type: "SPEAK_COMPLETE" }

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -5,7 +5,7 @@ import cors from "cors";
 
 const app = express();
 app.use(cors());
-app.use(express.static('public'))
+app.use(express.static("public"));
 
 run().catch((err) => console.log(err));
 
@@ -37,15 +37,17 @@ async function run() {
         words = "Hello, |this |is |a";
         break;
     }
-    words = words.split("|");
+    const wordlist = words.split("|");
     const interval = setInterval(() => {
-      if (words[counter]) {
+      if (wordlist[counter]) {
         const chunk =
-          words[counter] === "<v>"
+          wordlist[counter] === "<v>"
             ? `event: STREAMING_SET_VOICE\ndata:en-US-EmmaMultilingualNeural\n\n`
-            : words[counter] !== "[end]"
-              ? `event: STREAMING_CHUNK\ndata:${words[counter]}\n\n`
-              : `event: STREAMING_DONE\ndata:\n\n`;
+            : wordlist[counter] === "<l>"
+              ? `event: STREAMING_SET_LOCALE\ndata:fr-FR\n\n`
+              : wordlist[counter] !== "[end]"
+                ? `event: STREAMING_CHUNK\ndata:${wordlist[counter]}\n\n`
+                : `event: STREAMING_DONE\ndata:\n\n`;
         res.write(chunk);
         counter++;
       } else {

--- a/test/tts.test.ts
+++ b/test/tts.test.ts
@@ -58,6 +58,20 @@ describe("Synthesis test", async () => {
     expect(snapshot).toBeTruthy();
   });
 
+  test("synthesise with voice and locale setting", async () => {
+    actor.getSnapshot().context.ssRef.send({
+      type: "SPEAK",
+      value: {
+        utterance: "Bonjour !  Je suis Henri.",
+        voice: "fr-FR-HenriNeural",
+        locale: "fr-FR"
+      },
+    });
+    const snapshot = await waitForView(actor, "speaking", 500);
+    expect(snapshot).toBeTruthy();
+  });
+
+  
   test("synthesise, pause, speak again", async () => {
     actor.getSnapshot().context.ssRef.send({
       type: "SPEAK",


### PR DESCRIPTION
Before, the locale for TTS (which results in inserting the
<lang> tag) was only inherited from global settings. This change
allows specifying locale both as part of SPEAK event and, in case of
streaming, as a value of separate STREAMING_SET_LOCALE event.