### PR TITLE
Warn and don’t attempt to speak only punctuation symbols

### DIFF
--- a/src/tts.ts
+++ b/src/tts.ts
@@ -213,8 +213,8 @@ export const ttsMachine = setup({
       const wsaTTS = input.wsaTTS;
       const wsaUtt = input.wsaUtt;
 
-      if (["", " "].includes(input.utterance)) {
-        console.debug("[TTS] SPEAK: (empty utterance)");
+      if (!input.utterance.match(/[\p{L}\p{N}]/giu)) {
+        console.warn("[TTS] SPEAK: (utterance doesn't contain alphanumeric characters)");
         sendBack({ type: "SPEAK_COMPLETE" });
       } else {
         const content = wrapSSML(


### PR DESCRIPTION
This change checks whether the input to TTS contains digits and
letters. If it doesn’t, it won’t attempt to speak them and will
produce a SPEAK_COMPLETE event and a warning.