### PR TITLE
Stop speaking when only STREAMING_DONE is received

### DIFF
--- a/src/tts.ts
+++ b/src/tts.ts
@@ -356,6 +356,7 @@ export const ttsMachine = setup({
                         STREAMING_CHUNK: {
                           target: "Buffering",
                         },
+                        STREAMING_DONE: "BufferingDone",
                       },
                     },
                     Buffering: {

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -33,6 +33,9 @@ async function run() {
         words =
           "Hello, |this |is |a |<v>|test |of stre|aming |messa|ges |one |by |one!| |[end]";
         break;
+      case "onlydone":
+        words = "[end]";
+        break;
       case "noend":
         words = "Hello, |this |is |a";
         break;

--- a/test/tts.test.ts
+++ b/test/tts.test.ts
@@ -194,6 +194,17 @@ describe("Synthesis test", async () => {
     expect(snapshot).toBeTruthy();
   });
 
+  test("synthesise from stream, only STREAMING_DONE is sent", async () => {
+    actor.getSnapshot().context.ssRef.send({
+      type: "SPEAK",
+      value: { utterance: "", stream: "http://localhost:3000/sse/onlydone" },
+    });
+    await pause(2000);
+    const snapshot = actor.getSnapshot().context.ssRef.getSnapshot()
+    expect(snapshot.matches({Active: {AsrTtsManager: {Ready: "Idle"}}})).toBeTruthy();
+  });
+
+
   /** just for the reference (tests couldn't be run on mobile Safari) */
   test.skip("synthesise in chain, fails on mobile safari", async () => {
     actor.getSnapshot().context.ssRef.send({


### PR DESCRIPTION
For situations where, for some reason, STREAMING_DONE arrives
before (or instead of) the chunks.