### PR TITLE
Support authorization header for Azure proxy

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -3,6 +3,11 @@ name: Compile and package
 on:
   pull_request:
     branches: [ "master" ]
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
 
@@ -20,12 +25,9 @@ jobs:
       - run: yarn exec tsc
       - run: npm version prerelease --no-git-tag-version --preid=${{ format('pr{0}-{1}-{2}', github.event.number, github.run_attempt, github.run_id) }}
 
-      - uses: actions/setup-node@v4       
+      - uses: actions/setup-node@v6
         with:
-          node-version: '14.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to NPM registry
         run: npm publish --tag ${{ format('pr{0}', github.event.number) }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speechstate",
   "license": "GPL-3.0",
   "version": "2.16.0",
-  "homepage": "http://localhost/speechstate",
+  "homepage": "https://speechstate.maraev.me",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/src/getToken.ts
+++ b/src/getToken.ts
@@ -1,16 +1,42 @@
 import { fromPromise } from "xstate";
+import {
+  AzureSpeechCredentials,
+  AzureSpeechTokenProxyCredentials,
+} from "./types";
 
-export const getToken = fromPromise(async ({ input }: { input: any }) => {
-  if (typeof input.credentials === "string") {
-    return fetch(new Request(input.credentials)).then((data) => data.text());
-  } else {
-    return fetch(
-      new Request(input.credentials.endpoint, {
-        method: "POST",
-        headers: {
-          "Ocp-Apim-Subscription-Key": input.credentials.key,
-        },
-      }),
-    ).then((data) => data.text());
-  }
-});
+export const getToken = fromPromise(
+  async ({
+    input,
+  }: {
+    input: {
+      credentials:
+        | AzureSpeechTokenProxyCredentials
+        | AzureSpeechCredentials
+        | string;
+    };
+  }) => {
+    if (typeof input.credentials === "string") {
+      return fetch(new Request(input.credentials)).then((data) => data.text());
+    } else {
+      if ("proxyUrl" in input.credentials) {
+        return fetch(
+          new Request(
+            input.credentials.proxyUrl,
+            input.credentials.key && {
+              headers: { Authorization: `Bearer ${input.credentials.key}` },
+            },
+          ),
+        ).then((data) => data.text());
+      } else {
+        return fetch(
+          new Request(input.credentials.endpoint, {
+            method: "POST",
+            headers: {
+              "Ocp-Apim-Subscription-Key": input.credentials.key,
+            },
+          }),
+        ).then((data) => data.text());
+      }
+    }
+  },
+);

--- a/src/speechstate.ts
+++ b/src/speechstate.ts
@@ -14,8 +14,6 @@ import { getToken } from "./getToken";
 
 import type {
   Settings,
-  Agenda,
-  Hypothesis,
   RecogniseParameters,
   SpeechStateEvent,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,16 @@ export interface AzureSpeechCredentials {
   key: string;
 }
 
+export interface AzureSpeechTokenProxyCredentials {
+  proxyUrl: string;
+  key?: string;
+}
+
+/**
+ * @deprecated use `AzureSpeechTokenProxyCredentials` instead
+ */
+type DeprecatedAzureSpeechTokenProxyCredentials = string;
+
 /**
  * @deprecated use `AzureSpeechCredentials` instead
  */
@@ -19,7 +29,7 @@ export interface Settings {
   bargeIn: undefined | false | RecogniseParameters;
   locale?: string;
   noPonyfill?: boolean;
-  azureCredentials?: string | AzureSpeechCredentials;
+  azureCredentials?: AzureSpeechTokenProxyCredentials | AzureSpeechCredentials | DeprecatedAzureSpeechTokenProxyCredentials;
   azureRegion?: string;
   azureLanguageCredentials?: AzureLanguageCredentials;
   asrDefaultCompleteTimeout?: number;


### PR DESCRIPTION
This change adds a support for proxies for azure keys which require
additional authorisation. This is enabled by providing an object
`AzureSpeechTokenProxyCredentials` as credentials in `Settings`.

If the proxy doesn't require authorisation, it is recommended to use
the same object but omit the `key` field, instead of using bare string
URL which will be eventually deprecated.